### PR TITLE
docs: add Scalus implementation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # design-patterns
 
-This project is dedicated to simplifying complex Plutus smart contract design patterns on the Cardano blockchain through the creation of two distinct libraries: one for [Plutarch](https://github.com/Anastasia-Labs/plutarch-design-patterns) and another for [Aiken](https://github.com/Anastasia-Labs/aiken-design-patterns). These libraries are designed to abstract away some of the more unintuitive and lesser-known design patterns, making them more accessible to developers. Below is an overview of the key features and design patterns these libraries address:
+This project is dedicated to simplifying complex Plutus smart contract design patterns on the Cardano blockchain through the creation of libraries for [Plutarch](https://github.com/Anastasia-Labs/plutarch-design-patterns), [Aiken](https://github.com/Anastasia-Labs/aiken-design-patterns), and [Scalus](https://github.com/scalus3/scalus/tree/master/scalus-design-patterns). These libraries are designed to abstract away some of the more unintuitive and lesser-known design patterns, making them more accessible to developers. Below is an overview of the key features and design patterns these libraries address:
 
 ## Key Features
 


### PR DESCRIPTION
Add reference to Scalus design patterns implementation.

[Scalus](https://scalus.org) is a Scala 3 platform for developing Cardano smart contracts & decentralised applications.

The design patterns library currently implements:
- Stake Validator (withdraw zero trick)
- Transaction Level Minter
- Merkelized Validator
- Parameter validation
- UTxO Indexers (oneToOne, oneToMany, multi variants)
- Linked List (ordered and unordered)
- Validity Range Normalization

Repository: https://github.com/scalus3/scalus/tree/master/scalus-design-patterns